### PR TITLE
Command line options to preheat and home

### DIFF
--- a/connector_http.go
+++ b/connector_http.go
@@ -104,6 +104,18 @@ func (hc *HTTPConnector) Disconnect() (err error) {
 	return
 }
 
+func (hc *HTTPConnector) SendGCode(command string) (err error) {
+	// *** UNTESTED ***
+	r, err := hc.request().SetFormData(map[string]string{"command": command}).Post(hc.URL("/command"))
+	if err != nil {
+		return
+	}
+	if r.StatusCode != 200 {
+		err = fmt.Errorf("command error %d", r.StatusCode)
+	}
+	return
+}
+
 func (hc *HTTPConnector) Upload(payload *Payload) (err error) {
 	finished := make(chan empty, 1)
 	defer func() {

--- a/connector_http.go
+++ b/connector_http.go
@@ -104,15 +104,21 @@ func (hc *HTTPConnector) Disconnect() (err error) {
 	return
 }
 
-func (hc *HTTPConnector) SendGCode(command string) (err error) {
-	// *** UNTESTED ***
-	r, err := hc.request().SetFormData(map[string]string{"command": command}).Post(hc.URL("/command"))
-	if err != nil {
-		return
-	}
-	if r.StatusCode != 200 {
-		err = fmt.Errorf("command error %d", r.StatusCode)
-	}
+func (hc *HTTPConnector) SetToolTemperature(tool int, temperature int) (err error) {
+	// *** NOT IMPLEMENTED ***
+	err = fmt.Errorf("not implemented")
+	return
+}
+
+func (hc *HTTPConnector) SetBedTemperature(tool int, temperature int) (err error) {
+	// *** NOT IMPLEMENTED ***
+	err = fmt.Errorf("not implemented")
+	return
+}
+
+func (hc *HTTPConnector) Home() (err error) {
+	// *** NOT IMPLEMENTED ***
+	err = fmt.Errorf("not implemented")
 	return
 }
 

--- a/connector_sacp.go
+++ b/connector_sacp.go
@@ -69,6 +69,15 @@ func (sc *SACPConnector) Upload(payload *Payload) (err error) {
 	return
 }
 
+func (sc *SACPConnector) SendGCode(command string) (err error) {
+	err = SACP_set_temperature(sc.conn, TOOL_EXTRUDER, 0x00, 34, SACPTimeout*time.Second)
+	err = SACP_set_temperature(sc.conn, TOOL_EXTRUDER, 0x01, 35, SACPTimeout*time.Second)
+	err = SACP_set_temperature(sc.conn, TOOL_BED, 0x00, 27, SACPTimeout*time.Second)
+	err = SACP_set_temperature(sc.conn, TOOL_BED, 0x01, 27, SACPTimeout*time.Second)
+	// err = SACP_set_temperature(sc.conn, command, SACPTimeout*time.Second)
+	return
+}
+
 func init() {
 	Connector.RegisterHandler(&SACPConnector{})
 }

--- a/connector_sacp.go
+++ b/connector_sacp.go
@@ -70,10 +70,11 @@ func (sc *SACPConnector) Upload(payload *Payload) (err error) {
 }
 
 func (sc *SACPConnector) SendGCode(command string) (err error) {
-	err = SACP_set_temperature(sc.conn, TOOL_EXTRUDER, 0x00, 34, SACPTimeout*time.Second)
-	err = SACP_set_temperature(sc.conn, TOOL_EXTRUDER, 0x01, 35, SACPTimeout*time.Second)
-	err = SACP_set_temperature(sc.conn, TOOL_BED, 0x00, 27, SACPTimeout*time.Second)
-	err = SACP_set_temperature(sc.conn, TOOL_BED, 0x01, 27, SACPTimeout*time.Second)
+	// err = SACP_set_tool_temperature(sc.conn, 0x00, 31, SACPTimeout*time.Second)
+	// err = SACP_set_tool_temperature(sc.conn, 0x01, 32, SACPTimeout*time.Second)
+	// err = SACP_set_bed_temperature(sc.conn, 0x00, 21, SACPTimeout*time.Second)
+	// err = SACP_set_bed_temperature(sc.conn, 0x01, 21, SACPTimeout*time.Second)
+	err = SACP_home(sc.conn, SACPTimeout*time.Second)
 	// err = SACP_set_temperature(sc.conn, command, SACPTimeout*time.Second)
 	return
 }

--- a/connector_sacp.go
+++ b/connector_sacp.go
@@ -69,13 +69,18 @@ func (sc *SACPConnector) Upload(payload *Payload) (err error) {
 	return
 }
 
-func (sc *SACPConnector) SendGCode(command string) (err error) {
-	// err = SACP_set_tool_temperature(sc.conn, 0x00, 31, SACPTimeout*time.Second)
-	// err = SACP_set_tool_temperature(sc.conn, 0x01, 32, SACPTimeout*time.Second)
-	// err = SACP_set_bed_temperature(sc.conn, 0x00, 21, SACPTimeout*time.Second)
-	// err = SACP_set_bed_temperature(sc.conn, 0x01, 21, SACPTimeout*time.Second)
+func (sc *SACPConnector) SetToolTemperature(tool_id int, temperature int) (err error) {
+	err = SACP_set_tool_temperature(sc.conn, uint8(tool_id), uint16(temperature), SACPTimeout*time.Second)
+	return
+}
+
+func (sc *SACPConnector) SetBedTemperature(tool_id int, temperature int) (err error) {
+	err = SACP_set_bed_temperature(sc.conn, uint8(tool_id), uint16(temperature), SACPTimeout*time.Second)
+	return
+}
+
+func (sc *SACPConnector) Home() (err error) {
 	err = SACP_home(sc.conn, SACPTimeout*time.Second)
-	// err = SACP_set_temperature(sc.conn, command, SACPTimeout*time.Second)
 	return
 }
 

--- a/utils.go
+++ b/utils.go
@@ -126,6 +126,15 @@ func shouldBeFix(fpath string) bool {
 	return SmFixExtensions[ext]
 }
 
+func parseIntEnv(key string, defaultValue int) int {
+	if value, ok := os.LookupEnv(key); ok {
+		if v, err := strconv.Atoi(value); err == nil {
+			return v
+		}
+	}
+	return defaultValue
+}
+
 func parseBoolEnv(key string, defaultValue bool) bool {
 	if value, ok := os.LookupEnv(key); ok {
 		if v, err := strconv.ParseBool(value); err == nil {


### PR DESCRIPTION
This PR provides new command line options to pre-heat the tools (both extruder 1 & 2), the bed, and home everything.

It's very much targeted for 3D printing where preheating is relevant.

**IMPORTANT - this only implements the SACP protocol** - I have an Artisan, and that's all I can test against, but I think it'll work against other printers that use the SACP protocol.

PS: This is my first `go` project, so hopefully the code is not too nasty.

Thanks!