### PR TITLE
Fix truncated upload of size-changed (SMFix) G-code — Content-Length mismatch

### DIFF
--- a/connector_http.go
+++ b/connector_http.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"log"
@@ -152,24 +153,54 @@ func (hc *HTTPConnector) Upload(payload *Payload) (err error) {
 		log.SetOutput(os.Stderr)
 	}()
 
-	file := req.FileUpload{
-		ParamName: "file",
-		FileName:  payload.Name,
-		GetFileContent: func() (io.ReadCloser, error) {
-			rc, err := payload.StreamContent(NoFix)
-			if !NoFix && err == nil && payload.ShouldBeFix() {
-				log.SetOutput(os.Stderr)
-				log.Printf("G-Code fixed")
-				log.SetOutput(w)
-			} else if err != nil {
-				log.SetOutput(os.Stderr)
-				log.Printf("G-Code fix error(ignored): %s", err)
-				log.SetOutput(w)
-			}
-			return rc, err
-		},
-		FileSize: payload.Size,
-		// ContentType: "application/octet-stream",
+	var file req.FileUpload
+	if !NoFix && payload.ShouldBeFix() && payload.FixedFile == "" {
+		// FileSize below is captured when the FileUpload struct is built, so it must
+		// already equal the exact number of bytes that will be streamed. For a
+		// post-processed (SMFix) G-Code with no pre-saved fixed file, StreamContent
+		// only learns the fixed size asynchronously in its pipe goroutine -- too
+		// late. payload.Size (the original, pre-fix size) would then be sent as the
+		// Content-Length, the printer receives a size-mismatched upload, silently
+		// discards it and keeps the previously loaded job. Materialize this case up
+		// front so both the streamed content and FileSize are exact.
+		content, cerr := payload.GetContent(NoFix)
+		if cerr != nil {
+			log.SetOutput(os.Stderr)
+			log.Printf("G-Code fix error: %s", cerr)
+			return cerr
+		}
+		log.SetOutput(os.Stderr)
+		log.Printf("G-Code fixed")
+		log.SetOutput(w)
+		file = req.FileUpload{
+			ParamName: "file",
+			FileName:  payload.Name,
+			GetFileContent: func() (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewReader(content)), nil
+			},
+			FileSize: int64(len(content)),
+		}
+	} else {
+		// Non-fixed uploads, and files already pre-processed to disk (OutputDir),
+		// have a correct payload.Size, so stream them directly.
+		file = req.FileUpload{
+			ParamName: "file",
+			FileName:  payload.Name,
+			GetFileContent: func() (io.ReadCloser, error) {
+				rc, err := payload.StreamContent(NoFix)
+				if !NoFix && err == nil && payload.ShouldBeFix() {
+					log.SetOutput(os.Stderr)
+					log.Printf("G-Code fixed")
+					log.SetOutput(w)
+				} else if err != nil {
+					log.SetOutput(os.Stderr)
+					log.Printf("G-Code fix error(ignored): %s", err)
+					log.SetOutput(w)
+				}
+				return rc, err
+			},
+			FileSize: payload.Size,
+		}
 	}
 	r := hc.request(0)
 	r.SetFileUpload(file)


### PR DESCRIPTION
## Problem

When SMFix post-processing changes a G-code file's size **and** no fixed file was pre-saved to disk (the default — no `-o` / `OutputDir`), `HTTPConnector.Upload` streams the *fixed* content but announces the *original* (pre-fix) size as the multipart `FileSize` / `Content-Length`.

`req.FileUpload.FileSize` is read when the struct is built, but `StreamContent` only updates `payload.Size` **asynchronously**, inside its pipe goroutine (`connector.go`):

```go
pr, pw := io.Pipe()
go func() {
    cont, err := postProcess(p.File)
    ...
    p.Size = int64(len(cont)) // too late — FileSize was already captured
    pw.Write(cont)
    pw.Close()
}()
return pr, nil
```

So the request advertises the wrong length. The Snapmaker receives a size-mismatched multipart body, **silently discards it** (the HTTP call still returns OK to sm2uploader) and keeps the previously loaded job — a following print start then prints the *old* file. The effect scales with size; large fixed uploads are hit hardest (progress stalls near ~99–100 %, printer keeps the previous file, no error surfaced).

## Fix

For the post-processed-without-`FixedFile` path, materialize the fixed content up front via `GetContent` and set `FileSize` to its exact length.

Non-fixed uploads and `OutputDir` / `FixedFile` uploads keep streaming **unchanged** — their `payload.Size` is already correct before `Upload` runs, so no behavior change there. The pipe path already buffered the whole fixed file in memory (`postProcess` returns a full `[]byte`), so there is no added memory cost for the fixed path either.

## Testing

- `go build ./...` clean.
- 65+ MB OrcaSlicer uploads now land on the printer and start the correct file (previously the printer silently kept the prior job).
