### PR TITLE
Persist the printer token on connect (survive unclean restarts)

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -18,6 +18,10 @@ var (
 	errFileTooLarge = errors.New("File is too large.")
 )
 
+// OnPrinterUpdate, if set, is called after a successful connect so the caller
+// can persist the printer's (refreshed) token to disk. Set by main().
+var OnPrinterUpdate func(*Printer)
+
 type Payload struct {
 	File      io.Reader
 	Name      string
@@ -125,6 +129,12 @@ func (c *connector) Upload(printer *Printer, payload *Payload) error {
 				return err
 			}
 			defer h.Disconnect()
+
+			// Persist the (possibly refreshed) token so it survives restarts,
+			// including an unclean exit that skips the shutdown defer.
+			if OnPrinterUpdate != nil {
+				OnPrinterUpdate(printer)
+			}
 
 			if payload.Size > FILE_SIZE_MAX {
 				return errFileTooLarge

--- a/main.go
+++ b/main.go
@@ -83,6 +83,16 @@ func main() {
 
 	var printer *Printer
 	ls := NewLocalStorage(KnownHosts)
+	// Persist the token to known hosts as soon as it is (re)obtained on connect,
+	// so it survives restarts even on an unclean exit (the shutdown defer below
+	// only runs on a graceful exit).
+	OnPrinterUpdate = func(p *Printer) {
+		if p == nil {
+			return
+		}
+		ls.Add(p)
+		_ = ls.Save()
+	}
 	defer func() {
 		if printer != nil {
 			// update printer's token
@@ -140,8 +150,9 @@ func main() {
 				printer = printers[0]
 			}
 		} else {
-			// directly to printer using ip/hostname
-			printer = &Printer{IP: Host}
+			// directly to printer using ip/hostname; keep an ID so the token gets
+			// persisted (ls.Add skips ID-less printers)
+			printer = &Printer{IP: Host, ID: Host}
 		}
 	}
 


### PR DESCRIPTION
## Problem

The printer token is only written to the known-hosts file by the shutdown `defer` in `main()`, which runs **only on a graceful exit**. On an unclean exit — `SIGKILL`, container restart, OOM, power loss — a freshly authorized token is lost, so the next start needs another **touchscreen authorization**.

There is also a second gap: the IP-only fallback printer (`-host <ip>` without discovery) is created without an ID:

```go
printer = &Printer{IP: Host}
```

but `LocalStorage.Add` skips ID-less printers:

```go
func (ls *LocalStorage) Add(printers ...*Printer) {
    for _, p := range printers {
        if p.ID == "" {
            continue   // <- fallback printer never stored
        }
        ...
```

so that printer's token is never persisted, even on a clean exit.

## Fix

- Add an `OnPrinterUpdate` hook, invoked right after a successful connect, that `main()` wires to `ls.Add(printer)` + `ls.Save()` — persisting the (refreshed) token **immediately** instead of only at shutdown.
- Give the IP-only fallback printer an ID (its host) so `ls.Add` actually persists it.

No change to the normal shutdown path; this just makes persistence happen eagerly and closes the ID-less-fallback gap.

## Testing

- `go build ./...` clean.
- Token now survives `docker kill` / container restarts and unclean power cycles — no re-authorization on the touchscreen on the next upload.
